### PR TITLE
Add `tempo` to `require` form in README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ ways of manipulating this basic structure, but there's nothing to stop you from 
 You can create a melody with the `phrase` function. Here's a simple melody:
 
 ```clojure
-(require '[leipzig.melody :refer [bpm is phrase then times where with]])
+(require '[leipzig.melody :refer [bpm is phrase then times where with tempo]])
 
 (def melody
          ; Row,  row,  row   your  boat


### PR DESCRIPTION
`tempo` is used later in the example code. Add it to the `require` so
that copy-pasting code from the README works.