### PR TITLE
Allow to pass note play scheduling function

### DIFF
--- a/src/clj/leipzig/live.clj
+++ b/src/clj/leipzig/live.clj
@@ -35,22 +35,28 @@
        (melody/where :time (partial * 1000))
        (melody/after (overtone/now))))
 
+(def play-fn
+  "A function that plays a note via overtone/at"
+  (fn [epoch note]
+    (overtone/at epoch (play-note note))))
+
 (defn play
   "Plays notes now.
   e.g. (->> melody play)"
-  [notes] 
-  (->>
-    notes
-    translate
-    trickle
-    (map (fn [{epoch :time :as note}]
-           (->> (dissoc note :time)
-                play-note
-                (overtone/at epoch)
-                (when (< (overtone/now) epoch))))) ; Don't play notes in the past.
-    dorun
-    future
-    register))
+  ([notes]
+    (play play-fn notes))
+  ([play-fn notes]
+   (->>
+     notes
+     translate
+     trickle
+     (map (fn [{epoch :time :as note}]
+            (->> (dissoc note :time)
+                 (play-fn epoch)
+                 (when (< (overtone/now) epoch)))))         ; Don't play notes in the past.
+     dorun
+     future
+     register)))
 
 (defn- forever
   "Lazily loop riff forever. riff must start with a positive :time, otherwise there
@@ -71,5 +77,8 @@
 
        ; Later...
        (def melody nil)"
-  [riff]
-  (->> riff forever play))
+  ([riff]
+    (jam play-fn))
+  ([riff play-fn]
+   (->> riff forever
+        (play play-fn))))


### PR DESCRIPTION
The current implementation of `leipzig/live` uses `overtone/at` to schedule playing a note, but this works only with OSC events. In my use case I want to schedule MIDI out events which uses Java MIDI API. I'm doing some research about the best options, for now I'm using `overtone.at-at/at-at` with fixed thread pool. 

So in this PR I only make possible to pass own `play-fn` function to both `leipzig.live/play` and `jam`