### PR TITLE
Fix parameter to `Thread/sleep`

### DIFF
--- a/src/clj/leipzig/live.clj
+++ b/src/clj/leipzig/live.clj
@@ -9,7 +9,7 @@
 
 (defn- trickle [[note & others]]
   (when-let [{epoch :time} note]
-    (Thread/sleep (max 0 (- epoch (+ 100 (overtone/now)))))
+    (Thread/sleep (long (max 0 (- epoch (+ 100 (overtone/now))))))
     (cons note (lazy-seq (trickle others)))))
 
 (def channels (atom []))

--- a/src/clj/leipzig/live.clj
+++ b/src/clj/leipzig/live.clj
@@ -28,7 +28,10 @@
   (overtone/stop)
   (reset! channels []))
 
-(defn- translate [notes]
+(defn- translate
+  "Convert notes from relative :time in seconds to absolute :time in milliseconds,
+   starting now."
+  [notes]
   (->> notes
        (melody/after (-> notes first :time -)) ; Allow for notes that lead in.
        (melody/after 0.1) ; Make sure we have time to realise the seq.

--- a/src/cljc/leipzig/melody.cljc
+++ b/src/cljc/leipzig/melody.cljc
@@ -141,10 +141,14 @@
   "Transform both :time and :duration according to timing.
   e.g. (->> notes (tempo (bpm 120)))"
   [timing notes]
-  (letfn [(update-duration [{t :time d :duration :as note}]
-            (assoc note :duration (- (timing (+ t d)) (timing t))))]
+  (letfn [(update-durations [{t :time d :duration h :hold :as note}]
+                            (cond-> note
+                              d
+                              (assoc :duration (- (timing (+ t d)) (timing t)))
+                              h
+                              (assoc :hold (- (timing (+ t h)) (timing t)))))]
     (->> notes
-      (map update-duration)
+      (map update-durations)
       (where :time timing))))
 
 (defn cut

--- a/src/cljc/leipzig/melody.cljc
+++ b/src/cljc/leipzig/melody.cljc
@@ -121,9 +121,10 @@
        (after (duration earlier))
        (with earlier)))
 
-(defn mapthen [f & melodies]
+(defn mapthen
   "Apply f to each melody, then join them together.
   e.g. (mapthen drop-last [bassline vocals])"
+  [f & melodies]
   (->> melodies
        (apply map f)
        (reduce #(then %2 %1))))


### PR DESCRIPTION
Using Clojure version 1.10.3 (and later) loading leipzig/live.clj yields error:
```
#future[{:status :failed, :val #error {
 :cause "No matching method sleep found taking 1 args"
 :via
 [{:type java.util.concurrent.ExecutionException
   :message "java.lang.IllegalArgumentException: No matching method sleep found taking 1 args"
   :at [java.util.concurrent.FutureTask report "FutureTask.java" 122]}
  {:type java.lang.IllegalArgumentException
   :message "No matching method sleep found taking 1 args"
   :at [clojure.lang.Reflector invokeMatchingMethod "Reflector.java" 154]}]
 :trace
 [[clojure.lang.Reflector invokeMatchingMethod "Reflector.java" 154]
  [clojure.lang.Reflector invokeStaticMethod "Reflector.java" 332]
  [leipzig.live$trickle invokeStatic "live.clj" 12]
  [leipzig.live$trickle invoke "live.clj" 10]
  [leipzig.live$play$fn__20512 invoke "live.clj" 46]
  [clojure.core$binding_conveyor_fn$fn__5772 invoke "core.clj" 2034]
  [clojure.lang.AFn call "AFn.java" 18]
  [java.util.concurrent.FutureTask run "FutureTask.java" 317]
  [java.util.concurrent.ThreadPoolExecutor runWorker "ThreadPoolExecutor.java" 1144]
  [java.util.concurrent.ThreadPoolExecutor$Worker run "ThreadPoolExecutor.java" 642]
  [java.lang.Thread run "Thread.java" 1583]]}} 0x7c738bec]
```

Same issue as addressed in https://github.com/overtone/overtone/issues/497